### PR TITLE
check that Cygwin patchfile exists before asking to sign it

### DIFF
--- a/lib/pkg_pkg.cygpart
+++ b/lib/pkg_pkg.cygpart
@@ -498,7 +498,11 @@ __pkg_srcpkg() {
 		if check_prog gpg
 		then
 			__gpg_sign ${spkgdir}/${cygportfile} "CYGPORT SCRIPT";
-			__gpg_sign ${spkgdir}/${cygwin_patchfile} "CYGWIN PATCH";
+
+			if [ -f ${spkgdir}/${cygwin_patchfile} ]
+			then
+				__gpg_sign ${spkgdir}/${cygwin_patchfile} "CYGWIN PATCH";
+			fi
 
 			if [ -f ${spkgdir}/${src_patchfile} ]
 			then


### PR DESCRIPTION
When the Cygwin patchfile doesn't exist, don't ask the user to sign it. Saves typing a password just to get a file not found error from gpg.