### PR TITLE
Add command to make test releases

### DIFF
--- a/bin/cygport.in
+++ b/bin/cygport.in
@@ -599,6 +599,9 @@ do
 			__show_web;
 			_status=$?;
 			;;
+		package-test|pkg-test)
+			TESTRELEASE=cmdline;
+			;&
 		package|pkg)
 			__stage Packaging;
 			__log_init ${pkglog};

--- a/lib/help.cygpart
+++ b/lib/help.cygpart
@@ -46,6 +46,7 @@ __show_help() {
 		  test         run the package's test suite, if one exists
 		  install      install into a DESTDIR, and run post-installation steps
 		  package      create binary and source packages
+		  package-test create binary and source packages, marked as test
 		  upload       upload finished packages to cygwin.com
 		  announce     send an announcement email to cygwin.com
 		  finish       delete the working directory

--- a/lib/pkg_pkg.cygpart
+++ b/lib/pkg_pkg.cygpart
@@ -665,6 +665,14 @@ __pkg_dist() {
 #  libfoo-devel will use libfoo_devel_OBSOLETES.
 #****
 
+	pkg_testrelease=${TESTRELEASE+test:};
+	if [ "test:" = "${pkg_testrelease:-none}" ]
+	then
+		inform "Package hint files are prepared for a \e[1;31mtest\e[0;0m release\n"
+	else
+		inform "Package hint files are prepared for a \e[1;32mcurrent\e[0;0m release\n"
+	fi
+
 	n=0;
 	while defined pkg_name[${n}]
 	do
@@ -712,6 +720,7 @@ category: ${!pkg_category_var:-${CATEGORY}}
 requires: ${pkg_bin_requires} ${!pkg_requires_var}
 sdesc: "${!pkg_summary_var:-${SUMMARY}}"
 ldesc: "${!pkg_description_var:-${DESCRIPTION:-${!pkg_summary_var:-${SUMMARY}}}}"
+${pkg_testrelease}
 _EOF
 			if defined distsubdir
 			then
@@ -751,6 +760,7 @@ ldesc: "The ${obspkg} package is obsolete.  Selecting this package for
 installation will cause the ${pkg_name[${n}]} package, which replaces this
 one, to be installed instead."
 ${obssubdir:+external-source: ${PN}}
+${pkg_testrelease}
 _EOF
 		done
 
@@ -777,6 +787,7 @@ external-source: ${PN}
 sdesc: "Debug info for ${PN}"
 ldesc: "This package contains files necessary for debugging the
 ${PN} package with gdb."
+${pkg_testrelease}
 _EOF
 		fi
 
@@ -795,6 +806,7 @@ ldesc: "The ${obspkg} package is obsolete.  Selecting this package for
 installation will cause the ${PN}-debuginfo package, which replaces this
 one, to be installed instead."
 external-source: ${PN}
+${pkg_testrelease}
 _EOF
 		done
 	fi
@@ -820,6 +832,7 @@ category: ${!pkg_category_var:-${CATEGORY}}
 requires:
 sdesc: "${!pkg_summary_var:-${SUMMARY}}"
 ldesc: "${!pkg_description_var:-${DESCRIPTION:-${!pkg_summary_var:-${SUMMARY}}}}"
+${pkg_testrelease}
 skip:
 _EOF
 		else


### PR DESCRIPTION
This patch (originally by Achim Gratz) adds a mechanism for generating packages marked as 'test' as described in [1].

I'm not committed to any of the details, but I would like to get something with this functionality in, so tell me how you'd like it implemented and I'll do it...

[1] https://cygwin.com/ml/cygwin-apps/2016-12/msg00005.html
